### PR TITLE
use pg_dumpbinary when restoring to timescale databases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,15 @@ RUN apt-get update && \
 
 # Install postgresql-client-16
 RUN apt-get update && \
-    apt-get install -y postgresql-client-16 bash ncurses-bin && \
+    apt-get install -y postgresql-client-16 bash make ncurses-bin libdatetime-perl libdbd-pg-perl git && \
     rm -rf /var/lib/apt/lists/*
+
+# Install pg_dumpbinary
+RUN git clone https://github.com/lzlabs/pg_dumpbinary.git
+RUN cd pg_dumpbinary && \
+    perl Makefile.PL && \
+    make && \
+    make install
 
 WORKDIR /app
 


### PR DESCRIPTION
pg_dump does not work well when dumping databases with a large amount of binary data. This PR uses [pg_dumpbinary](https://github.com/lzlabs/pg_dumpbinary/tree/master) instead. If Timescale is not detected in the destination database, we still use pg_dump so that we can manaully remove the Timescale specific commands.

_Draft while working out some issues._
